### PR TITLE
Redirect failed package creation to help document

### DIFF
--- a/ckanext/datahub/auth.py
+++ b/ckanext/datahub/auth.py
@@ -3,6 +3,7 @@ import ckan.model as model
 import ckan.logic as logic
 import ckan.new_authz as new_authz
 from ckan.common import _
+from ckan.lib.base import c
 
 @logic.auth_sysadmins_check
 def datahub_package_create(context, data_dict):
@@ -18,8 +19,12 @@ def datahub_package_create(context, data_dict):
         check1 = new_authz.check_config_permission('create_dataset_if_not_in_organization') \
             or new_authz.check_config_permission('create_unowned_dataset')
 
+        #if not authorized and not a part of any org, redirect to help page on how to join one
         if not check1 and not new_authz.has_user_permission_for_some_org(user, 'create_dataset'):
-            h.redirect_to('/pages/requesting-an-organization')
+            if '/new' in c.environ['PATH_INFO']:
+                h.redirect_to('/pages/requesting-an-organization')
+            else:
+                return {'success': False, 'msg': _('User %s not authorized to create packages') % user}
 
     if not check1:
         return {'success': False, 'msg': _('User %s not authorized to create packages') % user}
@@ -35,7 +40,6 @@ def datahub_package_create(context, data_dict):
             org_id, user, 'create_dataset'):
         return {'success': False, 'msg': _('User %s not authorized to add dataset to this organization') % user}
     return {'success': True}
-
 
 
 def package_delete(context, data_dict):

--- a/ckanext/datahub/templates/package/search.html
+++ b/ckanext/datahub/templates/package/search.html
@@ -11,11 +11,9 @@
   <section class="module">
     <div class="module-content">
       {% block page_primary_action %}
-        {% if h.check_access('package_create') %}
           <div class="page_primary_action">
             {% link_for _('Add Dataset'), controller='package', action='new', class_='btn btn-primary', icon='plus-sign-alt' %}
           </div>
-        {% endif %}
       {% endblock %}
       {% block form %}
         {% set facets = {


### PR DESCRIPTION
Package creation on datahub.io requires users to be a member of at least one organisation. Attempting to create a package will redirect to a help document that explains this policy and how to create/join organisations.
