### PR TITLE
Copy link to import datapackage from extension

### DIFF
--- a/ckanext/datahub/templates/package/search.html
+++ b/ckanext/datahub/templates/package/search.html
@@ -13,6 +13,7 @@
       {% block page_primary_action %}
           <div class="page_primary_action">
             {% link_for _('Add Dataset'), controller='package', action='new', class_='btn btn-primary', icon='plus-sign-alt' %}
+            {% link_for _('Import Data Package'), controller='ckanext.datapackager.controllers.datapackage:DataPackageController', action='new', class_='btn', icon='plus-sign-alt' %}
           </div>
       {% endblock %}
       {% block form %}

--- a/ckanext/datahub/templates/package/search.html
+++ b/ckanext/datahub/templates/package/search.html
@@ -13,7 +13,9 @@
       {% block page_primary_action %}
           <div class="page_primary_action">
             {% link_for _('Add Dataset'), controller='package', action='new', class_='btn btn-primary', icon='plus-sign-alt' %}
-            {% link_for _('Import Data Package'), controller='ckanext.datapackager.controllers.datapackage:DataPackageController', action='new', class_='btn', icon='plus-sign-alt' %}
+            {% if 'datapackager' in g.plugins %}
+              {% link_for _('Import Data Package'), controller='ckanext.datapackager.controllers.datapackage:DataPackageController', action='new', class_='btn', icon='plus-sign-alt' %}
+            {% endif %}
           </div>
       {% endblock %}
       {% block form %}


### PR DESCRIPTION
Fixes #77

This is the cheap version of the fix that just copies the code from the template in the `ckanext-datapackager` template to this one. 

This also means that the `ckanext-datahub` extension will only work if the `ckanext-datapackager` extension is also installed but I guess that this can be assumed in this case of a one-page extension.