### PR TITLE
Handle properly importing authz from CKAN

### DIFF
--- a/ckanext/datahub/auth.py
+++ b/ckanext/datahub/auth.py
@@ -1,10 +1,16 @@
 import ckan.lib.helpers as h
 import ckan.model as model
 import ckan.logic as logic
-import ckan.authz as authz
 from ckan.common import _
 from ckan.lib.base import c
 from ckan.plugins import toolkit
+
+try:
+    # CKAN 2.5 and bellow
+    import ckan.new_authz as authz
+except ImportError:
+    # CKAN 2.6 and up
+    import ckan.authz as authz
 
 CREATE_DATASET_HELP_PAGE = 'https://discuss.okfn.org/t/creating-a-dataset-on-the-datahub/1627'
 

--- a/ckanext/datahub/auth.py
+++ b/ckanext/datahub/auth.py
@@ -1,7 +1,7 @@
 import ckan.lib.helpers as h
 import ckan.model as model
 import ckan.logic as logic
-import ckan.new_authz as new_authz
+import ckan.authz as authz
 from ckan.common import _
 from ckan.lib.base import c
 from ckan.plugins import toolkit
@@ -14,21 +14,21 @@ CREATE_DATASET_HELP_PAGE = 'https://discuss.okfn.org/t/creating-a-dataset-on-the
 def datahub_package_create(context, data_dict):
     from ckan.logic.auth.create import _check_group_auth
 
-    if new_authz.is_sysadmin(context.get('user')):
+    if authz.is_sysadmin(context.get('user')):
         return {'success': True}
 
     user = context['user']
-    if not new_authz.auth_is_registered_user():
+    if not authz.auth_is_registered_user():
         if '/new' in c.environ['PATH_INFO']:
             h.redirect_to(CREATE_DATASET_HELP_PAGE)
         else:
             return {'success': False, 'msg': _('You must login to create a dataset')}
 
-    check1 = new_authz.check_config_permission('create_dataset_if_not_in_organization') \
-        or new_authz.check_config_permission('create_unowned_dataset')
+    check1 = authz.check_config_permission('create_dataset_if_not_in_organization') \
+        or authz.check_config_permission('create_unowned_dataset')
 
     #if not authorized and not a part of any org, redirect to help page on how to join one
-    if not check1 and not new_authz.has_user_permission_for_some_org(user, 'create_dataset'):
+    if not check1 and not authz.has_user_permission_for_some_org(user, 'create_dataset'):
         if '/new' in c.environ['PATH_INFO']:
             h.redirect_to(CREATE_DATASET_HELP_PAGE)
         else:
@@ -41,7 +41,7 @@ def datahub_package_create(context, data_dict):
     # If an organization is given are we able to add a dataset to it?
     data_dict = data_dict or {}
     org_id = data_dict.get('organization_id')
-    if org_id and not new_authz.has_user_permission_for_group_or_org(
+    if org_id and not authz.has_user_permission_for_group_or_org(
             org_id, user, 'create_dataset'):
         return {'success': False, 'msg': _('User %s not authorized to add dataset to this organization') % user}
     return {'success': True}


### PR DESCRIPTION
In CKAN 2.6, the module `new_autz.py` was renamed to `authz.py`. In order for this extension to work properly for 2.6, it needs proper handling while importing that module.